### PR TITLE
Run check on bases before resolving PTM

### DIFF
--- a/quantumsim/algebra/algebra.py
+++ b/quantumsim/algebra/algebra.py
@@ -15,8 +15,8 @@ def _bases_equal(b1, b2) -> bool:
     """
     Test whether to bases are equal.
 
-    Returns true if the length of both bases are equal, as well as all basis vectors
-    of each element.
+    Returns true if the length of both bases are equal, and each basis in the tuples are
+    equal.
 
     Parameters
     ----------

--- a/quantumsim/algebra/algebra.py
+++ b/quantumsim/algebra/algebra.py
@@ -11,6 +11,25 @@ sigma = {
 }
 
 
+def _bases_equal(b1, b2) -> bool:
+    """
+    Test whether to bases are equal.
+
+    Returns true if the length of both bases are equal, as well as all basis vectors
+    of each element.
+
+    Parameters
+    ----------
+    b1: tuple of PauliBasis to compare
+    b2: tuple of PauliBasis to compare
+
+    Returns
+    -------
+    bool
+    """
+    return len(b1) == len(b2) and all(_b1 == _b2 for _b1, _b2 in zip(b1, b2))
+
+
 @lru_cache(maxsize=128)
 def bases_kron(bases):
     return reduce(np.kron, [b.vectors for b in bases])
@@ -40,6 +59,10 @@ def kraus_to_ptm(kraus, bases_in, bases_out):
 
 
 def ptm_convert_basis(ptm, bi_old, bo_old, bi_new, bo_new):
+    # Optimization: return PTM directly if old and new bases are equal
+    if _bases_equal(bi_old, bi_new) and _bases_equal(bo_old, bi_new):
+        return ptm
+
     shape = tuple(b.dim_pauli for b in chain(bo_new, bi_new))
     d_in = np.prod([b.dim_pauli for b in bi_old])
     d_out = np.prod([b.dim_pauli for b in bo_old])

--- a/quantumsim/algebra/algebra.py
+++ b/quantumsim/algebra/algebra.py
@@ -60,7 +60,7 @@ def kraus_to_ptm(kraus, bases_in, bases_out):
 
 def ptm_convert_basis(ptm, bi_old, bo_old, bi_new, bo_new):
     # Optimization: return PTM directly if old and new bases are equal
-    if _bases_equal(bi_old, bi_new) and _bases_equal(bo_old, bi_new):
+    if _bases_equal(bi_old, bi_new) and _bases_equal(bo_old, bo_new):
         return ptm
 
     shape = tuple(b.dim_pauli for b in chain(bo_new, bi_new))

--- a/quantumsim/circuits/circuit.py
+++ b/quantumsim/circuits/circuit.py
@@ -647,7 +647,7 @@ class Gate(GatePlaceholder):
         num_qubits = len(bases_in)
         if qubits is None:
             qubits = list(range(num_qubits))
-        return Gate(
+        return cls(
             qubits,
             bases_in[0].dim_hilbert,
             lambda: (ptm, bases_in, bases_out),


### PR DESCRIPTION
When resolving a PTM using `algebra.ptm_convert_basis`, first run a quick check on the in and out bases. If the bases are equal, do not run the einsum, since no conversion is needed.

This can greate improve runtime in particular cases.